### PR TITLE
Create build spec for raspberry pi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
         - "v*"
 
 jobs:
-    build-linux:
+    build-x86-linux:
         runs-on: ubuntu-latest
         permissions:
           contents: write
@@ -26,4 +26,25 @@ jobs:
               with:
                 files: |
                   opensyde_syde_sup/result/SYDEsup
+    build-arm64-linux:
+        runs-on: ubuntu-24.04-arm
+        permissions:
+          contents: write
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+            - name: Set up toolchain
+              run: sudo apt-get update && sudo apt-get install -y gcc-9 g++-9
+            - name: Build
+              run: |
+                cd opensyde_syde_sup/bat
+                chmod +x ./build.raspi.sh
+                ./build.raspi.sh
+                cp ../result/SYDEsup ../result/SYDEsup.aarch64
+                
+            - name: Publish as release
+              uses: softprops/action-gh-release@v1
+              with:
+                files: |
+                  opensyde_syde_sup/result/SYDEsup.aarch64
 

--- a/opensyde_syde_sup/bat/build.raspi.sh
+++ b/opensyde_syde_sup/bat/build.raspi.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#script usage: 
+# * ./build.sh -> build a cmake configuration, compile project and install build target
+# * ./build.sh -l -> "-l(int_config)" -> only build cmake configuration (needed for pc_lint_plus scripts)
+
+build_only_lint_config=false
+
+# exit with error code if a command fails
+set -e
+
+while getopts ':l' flag; do
+ case "$flag" in
+    l)
+        echo "Only build cmake configuration for pc_lint usage"
+        build_only_lint_config=true
+        ;;
+   \?)
+        echo "script usage:"
+        echo "./build.sh -> compile project"
+        echo "./build.sh -l -> -l(int_config) -> only build cmake configuration (for pc_lint usage)"
+        exit 1
+        ;;
+    esac
+done
+
+echo "create build directory 'temp'"
+rm -rf ../temp
+mkdir ../temp
+cd ../temp
+
+# this step is always needed
+echo "run cmake with toolchain file for 64bit compilation"
+
+cmake ../pjt -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../pjt/toolchain_raspi.cmake 
+
+# only build the whole thing if no flag was given
+if [ "$build_only_lint_config" = false ] ; then
+    echo "build and install"
+    cmake --build . --target all -- -j4
+    cmake --build . --target install
+fi
+
+#return
+cd ../bat

--- a/opensyde_syde_sup/pjt/toolchain_raspi.cmake
+++ b/opensyde_syde_sup/pjt/toolchain_raspi.cmake
@@ -1,0 +1,15 @@
+# cmake toolchain file for ubuntu 64 bit compilation
+# usage: cmake ../pjt -DCMAKE_TOOLCHAIN_FILE=../pjt/toolchain_ubuntu.cmake 
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm64)
+
+# use gcc-9 and g++-9 explicitly; that was what SYDEsup was originally tested with
+# change to "gcc" and "g++" to use default compilers
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_C_FLAGS "-march=armv8-a -Wno-deprecated-declarations -fPIC")
+set(CMAKE_CXX_COMPILER g++)
+set(CMAKE_CXX_FLAGS "-march=armv8-a -Wno-deprecated-declarations -fPIC")
+
+set(CMAKE_SHARED_LINKER_FLAGS "-march=armv8-a")
+


### PR DESCRIPTION
This is directly duplicated from the existing way of building code - with the smallest possible changes to create a build for ARM64.